### PR TITLE
fix: CVE-2026-50593 integer underflow in slotat macro

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+graphite2 (1.3.14-2deepin1) unstable; urgency=medium
+
+  * Fix CVE-2026-50593: integer underflow in slotat macro leading to out-
+    of-bounds write Crafted Graphite actions can induce an integer
+    underflow in the slotat macro, leading to an out-of-bounds write
+    prior to the slotmap. Add upstream patch to add bounds checking to
+    the slotat macro.
+
+ -- deepin-ci-robot <packages@deepin.org>  Tue, 09 Jun 2026 09:48:53 +0800
+
 graphite2 (1.3.14-2) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/patches/CVE-2026-50593.patch
+++ b/debian/patches/CVE-2026-50593.patch
@@ -1,0 +1,19 @@
+Description: Fix integer underflow in slotat macro
+ Crafted Graphite actions can induce an integer underflow in the slotat macro,
+ leading to an out-of-bounds write prior to the slotmap. This patch adds bounds
+ checking to the slotat macro.
+Origin: upstream, https://github.com/silnrsi/graphite/commit/ad78c6b7319909e1540c1b134e115ced03417866
+Bug: https://github.com/silnrsi/graphite/commit/ad78c6b7319909e1540c1b134e115ced03417866
+Last-Update: 2026-06-09
+
+--- a/src/inc/opcodes.h
++++ b/src/inc/opcodes.h
+@@ -76,7 +76,8 @@
+ 
+ #define push(n)             { *++sp = n; }
+ #define pop()               (*sp--)
+-#define slotat(x)           (map[(x)])
++#define slotat(x)           ((map + (x) >= &smap[-1] && map + (x) < smap.end()) ? \
++                                map[(x)] : (status = Machine::slot_offset_out_bounds, nullptr))
+ #define DIE                 { is=seg.last(); status = Machine::died_early; EXIT(1); }
+ #define POSITIONED          1

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@ do-not-require-future.diff
 spell-out-lesser-and-greater.diff 
 no-explicit-dot-font-settings.diff 
 explicit-pdflatex.diff
+CVE-2026-50593.patch


### PR DESCRIPTION
## Summary

CVE-2026-50593: Graphite before 1.3.15 has an integer underflow and resultant out-of-bounds write via Graphite actions, because slotat does not ensure that an offset is within the allowed slot-map range.

## Changes

- Add upstream bounds check to the `slotat` macro in `src/inc/opcodes.h`
- The fix ensures the offset is within the valid slot-map range before access

## Patch

Upstream commit: https://github.com/silnrsi/graphite/commit/ad78c6b7319909e1540c1b134e115ced03417866